### PR TITLE
Small fix to build with GHC 7.0.x

### DIFF
--- a/Crypto/Random/AESCtr.hs
+++ b/Crypto/Random/AESCtr.hs
@@ -46,7 +46,7 @@ import Data.Bits (xor, (.&.))
 import Data.Serialize
 #else
 import Foreign.Ptr
-import Foreign.ForeignPtr.Unsafe (unsafeForeignPtrToPtr)
+import Foreign.ForeignPtr (unsafeForeignPtrToPtr)
 import Foreign.Storable
 import qualified Data.ByteString.Internal as B
 #endif


### PR DESCRIPTION
Changed the Foreign.ForeignPtr.Unsafe to Foreign.ForeignPtr so this package will build with GHC 7.0.x.
