### PR TITLE
Avoid declaring doc files as runtime data files

### DIFF
--- a/cprng-aes.cabal
+++ b/cprng-aes.cabal
@@ -28,7 +28,7 @@ Category:            Cryptography
 stability:           experimental
 Cabal-Version:       >=1.8
 Homepage:            http://github.com/vincenthz/hs-cprng-aes
-data-files:          README.md
+extra-doc-files:     README.md
 
 Library
   Build-Depends:     base >= 3 && < 5


### PR DESCRIPTION
`README.md` is not required as a runtime data file.
